### PR TITLE
[GRDM-38170] Set default value for hashes field (async version)

### DIFF
--- a/osfclient/models/file.py
+++ b/osfclient/models/file.py
@@ -60,7 +60,8 @@ class File(OSFCore):
                                                  'attributes', 'date_modified')
         self.size = self._get_attribute(file, 'attributes', 'size')
         self.hashes = self._get_attribute(file,
-                                          'attributes', 'extra', 'hashes')
+                                          'attributes', 'extra', 'hashes',
+                                          default={})
 
     def __str__(self):
         return '<File [{0}, {1}]>'.format(self.id, self.path)


### PR DESCRIPTION
WaterButler APIへのアクセスの際に、OneDrive等`hashes`フィールドを`extra`メタデータ内に持たないProviderへのアクセスを行った際にKeyErrorが発生する問題(GRDM-38170)への対応です。

デフォルト値を `{}` にすることで、`hashes`フィールドがない場合でも処理が継続するようにしています。
(ダウンロード・アップロードの効率化のために`hashes.md5`を参照していますが、Noneが返るのでハッシュチェックがスキップされるだけですので動作に影響はありません。)