### PR TITLE
[GRDM-38505] タイムアウト見直し

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,7 @@ cache:
 
 env:
   matrix:
-    - DISTRIB="conda" PYTHON_VERSION="3.5" COVERAGE="true"
-    - DISTRIB="conda" PYTHON_VERSION="3.6" COVERAGE="false"
-    - DISTRIB="conda" PYTHON_VERSION="2.7" COVERAGE="false"
+    - DISTRIB="conda" PYTHON_VERSION="3.8" COVERAGE="true"
 
 install: source build_tools/travis_install.sh
 
@@ -37,6 +35,6 @@ deploy:
     on:
       tags: true
       repo: osfclient/osfclient
-      condition: "$PYTHON_VERSION = 3.5"
+      condition: "$PYTHON_VERSION = 3.8"
     password:
       secure: SeqLSRnqFqiJgNMvc3E9oJ7evptcnt9a0avlLr95GaPbdAAw/Hp3P00pGCg5e6veCoKPvQa/EK8sl4dphRhnSwIgfVsKRYgof5z8tiKzSuZn4rSSomfFBmmgdRml0osbQ6XOunFyceZP/TZw++Fch9iGwtC9ewNzb3Y1jQf/f/gb+QRa6OcE6mMDQtGZbwkmY1rzl2CgJIM9iBWh164YMSAZehmvENJwZUjcHXrdLfbKD4u85OTsHAuUycsC9PBjA8bTJt5DTEHwkHNToVc/0eT1ZYuiDSmfFC8i1fJvZqVD8zrglhHSRIQn8n7jB8pAXFUnBsrwhD2cVDqiu5RQ0AU5MJf+ffN0EhTALpVjs9U//UEfSBQ7vPGgCmjEwAmR3Cpqyr8PmsgT7L+I5jxGkrmZ3uWrH6qm8d91EoF1A6L7SmQtclaMSNHfmY4me7QWNamZiyXt4Wl4RrQJOJ+q65IaFDaZA8xD+CockpMNZDY97WZlQt/i20sQRREkeS6NFrZvzyhotjS0w6Jm6feJVqL6X6k+h9vG0hX/rVwHW/36DnIg/EL9W3U2SluSqU/Q76YTLGxb5Od5dw/JOLxREy2VzBNaN4Z0OlMM7UP8btW7MmqI2IyQm+GT+653SwaWwsEry6MdV3KfcCWeq+1U6CPtqw2QWT7D2ZFtBt0Hjb0=

--- a/osfclient/models/core.py
+++ b/osfclient/models/core.py
@@ -22,6 +22,9 @@ class OSFCore(object):
     async def _get(self, url, *args, **kwargs):
         return await self.session.get(url, *args, **kwargs)
 
+    def _stream(self, method, url, *args, **kwargs):
+        return self.session.stream(method, url, *args, **kwargs)
+
     async def _put(self, url, *args, **kwargs):
         return await self.session.put(url, *args, **kwargs)
 

--- a/osfclient/models/session.py
+++ b/osfclient/models/session.py
@@ -3,7 +3,7 @@ import httpx
 from ..exceptions import UnauthorizedException
 
 
-DEFAULT_TIMEOUT = httpx.Timeout(5.0, connect=30.0, read=None)
+DEFAULT_TIMEOUT = httpx.Timeout(30.0, read=None)
 
 class OSFSession(httpx.AsyncClient):
     auth = None

--- a/osfclient/models/session.py
+++ b/osfclient/models/session.py
@@ -3,12 +3,14 @@ import httpx
 from ..exceptions import UnauthorizedException
 
 
+DEFAULT_TIMEOUT = httpx.Timeout(5.0, read=None)
+
 class OSFSession(httpx.AsyncClient):
     auth = None
 
-    def __init__(self):
+    def __init__(self, timeout=DEFAULT_TIMEOUT):
         """Handle HTTP session related work."""
-        super(OSFSession, self).__init__()
+        super(OSFSession, self).__init__(timeout=timeout)
         self.headers.update({
             # Only accept JSON responses
             'Accept': 'application/vnd.api+json',

--- a/osfclient/models/session.py
+++ b/osfclient/models/session.py
@@ -3,7 +3,7 @@ import httpx
 from ..exceptions import UnauthorizedException
 
 
-DEFAULT_TIMEOUT = httpx.Timeout(5.0, read=None)
+DEFAULT_TIMEOUT = httpx.Timeout(5.0, connect=30.0, read=None)
 
 class OSFSession(httpx.AsyncClient):
     auth = None

--- a/osfclient/models/session.py
+++ b/osfclient/models/session.py
@@ -49,6 +49,10 @@ class OSFSession(httpx.AsyncClient):
             raise UnauthorizedException()
         return response
 
+    def stream(self, method, url, *args, **kwargs):
+        kwargs_ = self.modify_kwargs(kwargs)
+        return super(OSFSession, self).stream(method, url, *args, **kwargs_)
+
     async def get(self, url, *args, **kwargs):
         kwargs_ = self.modify_kwargs(kwargs)
         response = await super(OSFSession, self).get(url, *args, **kwargs_)

--- a/osfclient/models/storage.py
+++ b/osfclient/models/storage.py
@@ -11,6 +11,7 @@ from ..utils import checksum
 from ..utils import file_empty
 from ..utils import get_local_file_size
 from ..utils import norm_remote_path
+from ..utils import ensure_async_generator
 
 
 if six.PY2:
@@ -92,8 +93,8 @@ class Storage(OSFCore, ContainerMixin):
         To force overwrite of an existing file, set `force=True`.
         To overwrite an existing file only if the files differ, set `update=True`
         """
-        #if 'b' not in fp.mode:
-        #    raise ValueError("File has to be opened in binary mode.")
+        if hasattr(fp, 'mode') and 'b' not in fp.mode:
+            raise ValueError("File has to be opened in binary mode.")
 
         # all paths are assumed to be absolute
         path = norm_remote_path(path)
@@ -117,29 +118,46 @@ class Storage(OSFCore, ContainerMixin):
         # handling in requests. If we pass a file like object to data that
         # turns out to be of length zero then no file is created on the OSF.
         # See: https://github.com/osfclient/osfclient/pull/135
-        #if file_empty(fp):
-        #    response = await self._put(url, params={'name': fname}, data=b'')
-        #else:
-        try:
-            response = await self._put(url, params={'name': fname}, data=fp)
-        except ConnectionError:
-            connection_error = True
+        if file_empty(fp):
+            response = await self._put(url, params={'name': fname}, data=b'')
+        else:
+            try:
+                response = await self._put(url, params={'name': fname}, data=fp)
+            except ConnectionError:
+                connection_error = True
 
         if connection_error or response.status_code == 409:
-            # find the upload URL for the file we are trying to update
-            async for file_ in self.files:
-                if norm_remote_path(file_.path) == path:
-                    if not force:
-                        if checksum(path) == file_.hashes.get('md5'):
-                            # If the hashes are equal and force is False,
-                            # we're done here
-                            break
-                    # in the process of attempting to upload the file we
-                    # moved through it -> reset read position to beginning
-                    # of the file
-                    #fp.seek(0)
-                    await file_.update(fp)
-                    break
+            if not force and not update:
+                # one-liner to get file size from file pointer from
+                # https://stackoverflow.com/a/283719/2680824
+                file_size_bytes = get_local_file_size(fp)
+                large_file_cutoff = 2**20 # 1 MB in bytes
+                if connection_error and file_size_bytes < large_file_cutoff:
+                    msg = (
+                        "There was a connection error which might mean {} " +
+                        "already exists. Try again with the `--force` flag " +
+                        "specified."
+                    ).format(path)
+                    raise RuntimeError(msg)
+                else:
+                    # note in case of connection error, we are making an inference here
+                    raise FileExistsError(path)
+
             else:
-                raise RuntimeError("Could not create a new file at "
-                                   "({}) nor update it.".format(path))
+                # find the upload URL for the file we are trying to update
+                async for file_ in ensure_async_generator(self.files):
+                    if norm_remote_path(file_.path) == path:
+                        if not force:
+                            if checksum(path) == file_.hashes.get('md5'):
+                                # If the hashes are equal and force is False,
+                                # we're done here
+                                break
+                        # in the process of attempting to upload the file we
+                        # moved through it -> reset read position to beginning
+                        # of the file
+                        fp.seek(0)
+                        await file_.update(fp)
+                        break
+                else:
+                    raise RuntimeError("Could not create a new file at "
+                                    "({}) nor update it.".format(path))

--- a/osfclient/tests/mocks.py
+++ b/osfclient/tests/mocks.py
@@ -145,3 +145,26 @@ class FakeResponse:
 
 def FutureFakeResponse(status_code, json):
     return FutureWrapper(FakeResponse(status_code, json))
+
+
+class AsyncIterator:
+    def __init__(self, seq):
+        self.iter = iter(seq)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self.iter)
+        except StopIteration:
+            raise StopAsyncIteration
+
+
+class FutureStreamResponse(MagicMock):
+    def __init__(self, response):
+        super(FutureStreamResponse, self).__init__()
+        resp = MagicMock()
+        resp.status_code = response.status_code
+        resp.aiter_bytes = lambda: AsyncIterator([response.raw])
+        self.__aenter__ = MagicMock(return_value=FutureWrapper(resp))

--- a/osfclient/tests/test_session.py
+++ b/osfclient/tests/test_session.py
@@ -44,7 +44,7 @@ async def test_unauthorized_put(mock_put):
     with pytest.raises(UnauthorizedException):
         await session.put(url)
 
-    mock_put.assert_called_once_with(url)
+    mock_put.assert_called_once_with(url, follow_redirects=True)
 
 
 @pytest.mark.asyncio
@@ -62,7 +62,7 @@ async def test_unauthorized_get(mock_get):
     with pytest.raises(UnauthorizedException):
         await session.get(url)
 
-    mock_get.assert_called_once_with(url)
+    mock_get.assert_called_once_with(url, follow_redirects=True)
 
 
 @pytest.mark.asyncio
@@ -80,7 +80,7 @@ async def test_put(mock_put):
     response = await session.put(url)
 
     assert response == mock_response
-    mock_put.assert_called_once_with(url)
+    mock_put.assert_called_once_with(url, follow_redirects=True)
 
 
 @pytest.mark.asyncio
@@ -98,4 +98,4 @@ async def test_get(mock_get):
     response = await session.get(url)
 
     assert response == mock_response
-    mock_get.assert_called_once_with(url)
+    mock_get.assert_called_once_with(url, follow_redirects=True)

--- a/osfclient/tests/test_uploading.py
+++ b/osfclient/tests/test_uploading.py
@@ -123,8 +123,8 @@ async def test_recursive_upload(OSF_project):
     assert call('foobar/baz/bar.txt', 'rb') in fake_open.mock_calls
     assert call('foobar/baz/abc.txt', 'rb') in fake_open.mock_calls
     # two directories with two files each -> four calls plus all the
-    # context manager __enter__ and __exit__ calls
-    assert len(fake_open.mock_calls) == 4 + 4*2
+    # context manager __enter__, __exit__ and close calls
+    assert len(fake_open.mock_calls) == 4 + 4*3
 
     fake_storage.assert_has_calls([
         call.create_file('BAR/./bar.txt', mock.ANY, force=False, update=False),
@@ -172,8 +172,8 @@ async def test_recursive_upload_with_subdir(OSF_project):
     assert call('foobar/baz/bar.txt', 'rb') in fake_open.mock_calls
     assert call('foobar/baz/abc.txt', 'rb') in fake_open.mock_calls
     # two directories with two files each -> four calls plus all the
-    # context manager __enter__ and __exit__ calls
-    assert len(fake_open.mock_calls) == 4 + 4*2
+    # context manager __enter__, __exit__, close calls
+    assert len(fake_open.mock_calls) == 4 + 4*3
 
     fake_storage.assert_has_calls([
         call.create_file('BAR/foobar/./bar.txt', mock.ANY,

--- a/osfclient/utils.py
+++ b/osfclient/utils.py
@@ -64,12 +64,14 @@ def makedirs(path, mode=511, exist_ok=False):
 
 def file_empty(fp):
     """Determine if a file is empty or not."""
+    if not hasattr(fp, 'peek'):
+        # If a Reader does not support peek, it is not considered empty
+        return False
     # for python 2 we need to use a homemade peek()
     if six.PY2:
         contents = fp.read()
         fp.seek(0)
         return not bool(contents)
-
     else:
         return not fp.peek()
 

--- a/setup.py
+++ b/setup.py
@@ -52,10 +52,8 @@ setup(
         # Indicate who your project is intended for
         'Intended Audience :: Developers',
         'Intended Audience :: Science/Research',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.8',
         'License :: OSI Approved :: BSD License',
         'Topic :: Utilities'
     ],


### PR DESCRIPTION
特にデフォルトストレージにおいて、128MB以上のファイルをアップロードする際など、Responseが返ってくるまでに5秒(httpxライブラリのデフォルトタイムアウト)を超えるとReadTimeoutが発生する問題の修正。

- GRDMのタイムアウトに合わせるため、rdmclientではReadTimeoutはチェックしないようにする。また、それ以外のタイムアウトを30秒とする
- GETの際にstreaming APIを通じてデータを取得するように修正。ユニットテストも合わせて修正