### PR TITLE
[GRDM-43551] Fix file.remove never awaited

### DIFF
--- a/osfclient/cli.py
+++ b/osfclient/cli.py
@@ -377,7 +377,7 @@ async def remove(args):
     f = await find_by_path(store, remote_path)
     if f is None:
         sys.exit('No files found to remove.')
-    f.remove()
+    await f.remove()
 
 
 @might_need_auth


### PR DESCRIPTION
This fixes the error that occurs when trying to delete a file.

```
/Users/xxx/workspace/rdmclient/osfclient/cli.py:380: RuntimeWarning: coroutine 'File.remove' was never awaited
  f.remove()
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
```

