### PR TITLE
[GRDM-46135] Fix for problem of uploading large files (>2GB)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -92,6 +92,11 @@ project ID create ``.osfcli.config``:
 after which you can simply run ``osf ls`` to list the contents of the
 project.
 
+You can also specify the following environment variables.
+
+- OSF_CLIENT_TIMEOUT - the client timeout for requests to the OSF
+
+
 Contributing
 ============
 

--- a/example/test-large-file.sh
+++ b/example/test-large-file.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# test-large-file.sh: Test the upload(create / update) and download of a large(2GB) file
+# Usage: test-large-file.sh <project_id> <storage_provider>
+
+set -e
+
+export PROJECT_ID=$1
+export STORAGE_PROVIDER=$2
+
+if [ -z "$PROJECT_ID" ]; then
+    echo "Usage: $0 <project_id> <storage_provider>"
+    exit 1
+fi
+if [ -z "$STORAGE_PROVIDER" ]; then
+    echo "Usage: $0 <project_id> <storage_provider>"
+    exit 1
+fi
+
+# Set the client timeout to 10 minutes
+export OSF_CLIENT_TIMEOUT=600
+
+# OSF_DEBUG: Set to --debug to enable debug output
+
+# Create a large file
+dd if=/dev/urandom of=large-file-2g bs=1M count=2000
+md5sum large-file-2g
+
+# Upload the large file
+osf -p ${PROJECT_ID} --base-url https://api.rdm.nii.ac.jp/v2/ ${OSF_DEBUG} upload large-file-2g ${STORAGE_PROVIDER}/large-file-2g
+
+# Download the large file
+osf -p ${PROJECT_ID} --base-url https://api.rdm.nii.ac.jp/v2/ ${OSF_DEBUG} fetch ${STORAGE_PROVIDER}/large-file-2g large-file-2g.downloaded
+
+# Check the downloaded file
+md5sum large-file-2g.downloaded
+rm large-file-2g.downloaded
+
+# Create a large file(for overwrite)
+dd if=/dev/urandom of=large-file-2g bs=1M count=2000
+md5sum large-file-2g
+
+# Overwrite the large file
+osf -p ${PROJECT_ID} --base-url https://api.rdm.nii.ac.jp/v2/ ${OSF_DEBUG} upload -U large-file-2g ${STORAGE_PROVIDER}/large-file-2g
+
+# Download the large file
+osf -p ${PROJECT_ID} --base-url https://api.rdm.nii.ac.jp/v2/ ${OSF_DEBUG} fetch ${STORAGE_PROVIDER}/large-file-2g large-file-2g.downloaded
+
+# Check the downloaded file
+md5sum large-file-2g.downloaded
+
+# Remove the large file
+osf -p ${PROJECT_ID} --base-url https://api.rdm.nii.ac.jp/v2/ ${OSF_DEBUG} remove ${STORAGE_PROVIDER}/large-file-2g
+
+# Clean up
+rm large-file-2g large-file-2g.downloaded

--- a/osfclient/models/file.py
+++ b/osfclient/models/file.py
@@ -7,6 +7,7 @@ from typing import AsyncGenerator, Dict, Type, TypeVar
 from .core import OSFCore
 from ..exceptions import FolderExistsException, UnauthorizedException
 from ..utils import file_empty
+from .utils import chunked_bytes_iterator
 
 
 logger = logging.getLogger(__name__)
@@ -132,7 +133,10 @@ class File(OSFCore):
         # turns out to be of length zero then no file is created on the OSF
         if not await file_empty(fp):
             logger.info("Uploading file: %s", self.path)
-            response = await self._put(url, content=fp)
+            response = await self._put(
+                url,
+                content=chunked_bytes_iterator(fp) if hasattr(fp, 'read') else fp,
+            )
         else:
             logger.info("File is empty, uploading zero-length bytes.")
             response = await self._put(url, content=b'')

--- a/osfclient/models/session.py
+++ b/osfclient/models/session.py
@@ -1,9 +1,23 @@
+import os
 import httpx
 
 from ..exceptions import UnauthorizedException
 
 
-DEFAULT_TIMEOUT = httpx.Timeout(30.0, read=None)
+def _parse_timeout(timeout, default):
+    timeout = timeout.strip()
+    if not timeout:
+        return default
+    return float(timeout)
+
+
+# rdmclient needs to support uploading large (>GB) files, so
+# the timeout period can be set using the OSF_CLIENT_TIMEOUT environment variable.
+DEFAULT_TIMEOUT = httpx.Timeout(
+    _parse_timeout(os.environ.get('OSF_CLIENT_TIMEOUT', ''), default=30.0),
+    read=None
+)
+
 
 class OSFSession(httpx.AsyncClient):
     def __init__(self, timeout=DEFAULT_TIMEOUT):

--- a/osfclient/models/utils.py
+++ b/osfclient/models/utils.py
@@ -1,0 +1,18 @@
+from typing import Any, AsyncIterable
+
+
+DEFAULT_UPLOAD_BLOCK_SIZE = 1024 * 1024 * 128  # 128 MB
+
+
+async def chunked_bytes_iterator(
+    content: Any,
+    chunk_size=DEFAULT_UPLOAD_BLOCK_SIZE
+) -> AsyncIterable[bytes]:
+    """Yield chunks of bytes from an asynchronous file-like object."""
+    if not hasattr(content, 'read'):
+        raise ValueError('content must have a read method')
+    while True:
+        chunk = await content.read(chunk_size)
+        if len(chunk) == 0:
+            break
+        yield chunk

--- a/osfclient/tests/test_storage.py
+++ b/osfclient/tests/test_storage.py
@@ -123,7 +123,9 @@ async def test_iterate_files_and_folders():
 
 
 @pytest.mark.asyncio
-async def test_create_existing_file():
+@patch('osfclient.models.storage.chunked_bytes_iterator',
+       return_value=b'TEST')
+async def test_create_existing_file(mock_chunked_bytes_iterator):
     # try to create file with a name that is already taken
     new_file_url = ('https://files.osf.io/v1/resources/9zpcy/providers/' +
                     'osfstorage/foo123/')
@@ -140,8 +142,10 @@ async def test_create_existing_file():
     with pytest.raises(exception):
         await store.create_file('foo.txt', fake_fp)
 
+    mock_chunked_bytes_iterator.assert_called_once_with(fake_fp)
+
     store._put.assert_called_once_with(new_file_url,
-                                       content=fake_fp,
+                                       content=b'TEST',
                                        params={'name': 'foo.txt'})
 
     assert fake_fp.call_count == 0
@@ -367,7 +371,9 @@ async def test_update_existing_file_fails():
 
 
 @pytest.mark.asyncio
-async def test_create_new_file():
+@patch('osfclient.models.storage.chunked_bytes_iterator',
+       return_value=b'TEST')
+async def test_create_new_file(mock_chunked_bytes_iterator):
     # create a new file at the top level
     new_file_url = ('https://files.osf.io/v1/resources/9zpcy/providers/' +
                     'osfstorage/foo123/')
@@ -379,15 +385,19 @@ async def test_create_new_file():
 
     await store.create_file('foo.txt', fake_fp)
 
+    mock_chunked_bytes_iterator.assert_called_once_with(fake_fp)
+
     store._put.assert_called_once_with(new_file_url,
-                                       content=fake_fp,
+                                       content=b'TEST',
                                        params={'name': 'foo.txt'})
 
     assert fake_fp.call_count == 0
 
 
 @pytest.mark.asyncio
-async def test_create_new_file_subdirectory():
+@patch('osfclient.models.storage.chunked_bytes_iterator',
+       return_value=b'TEST')
+async def test_create_new_file_subdirectory(mock_chunked_bytes_iterator):
     # test a new file in a new subdirectory
     new_file_url = ('https://files.osf.io/v1/resources/9zpcy/providers/' +
                     'osfstorage/bar12/')
@@ -416,8 +426,10 @@ async def test_create_new_file_subdirectory():
     with patch.object(Storage, '_put', side_effect=simple_put) as mock_put:
         await store.create_file('bar/foo.txt', fake_fp)
 
+    mock_chunked_bytes_iterator.assert_called_once_with(fake_fp)
+
     expected = [call(new_folder_url, params={'name': 'bar'}),
-                call(new_file_url, params={'name': 'foo.txt'}, content=fake_fp)]
+                call(new_file_url, params={'name': 'foo.txt'}, content=b'TEST')]
     assert mock_put.call_args_list == expected
     assert fake_fp.call_count == 0
 
@@ -445,7 +457,9 @@ async def test_create_new_zero_length_file():
 
 
 @pytest.mark.asyncio
-async def test_create_small_file_connection_error():
+@patch('osfclient.models.storage.chunked_bytes_iterator',
+       return_value=b'TEST')
+async def test_create_small_file_connection_error(mock_chunked_bytes_iterator):
     # turn a httpx.HTTPError into a RuntimeError with a more helpful
     # message that the file might exist
     new_file_url = ('https://files.osf.io/v1/resources/9zpcy/providers/' +
@@ -466,15 +480,19 @@ async def test_create_small_file_connection_error():
         with pytest.raises(exception):
             await store.create_file('foo.txt', fake_fp)
 
+    mock_chunked_bytes_iterator.assert_called_once_with(fake_fp)
+
     store._put.assert_called_once_with(new_file_url,
-                                       content=fake_fp,
+                                       content=b'TEST',
                                        params={'name': 'foo.txt'})
 
     assert fake_fp.call_count == 0
 
 
 @pytest.mark.asyncio
-async def test_create_big_file_connection_error(monkeypatch):
+@patch('osfclient.models.storage.chunked_bytes_iterator',
+       return_value=b'TEST')
+async def test_create_big_file_connection_error(mock_chunked_bytes_iterator):
     # with a "big" file, we're more confident that a connection error means the
     # file alredy exists, so raise FileExistsError without hedging
     new_file_url = ('https://files.osf.io/v1/resources/9zpcy/providers/' +
@@ -495,8 +513,10 @@ async def test_create_big_file_connection_error(monkeypatch):
         with pytest.raises(exception):
             await store.create_file('foo.txt', fake_fp)
 
+    mock_chunked_bytes_iterator.assert_called_once_with(fake_fp)
+
     store._put.assert_called_once_with(new_file_url,
-                                       content=fake_fp,
+                                       content=b'TEST',
                                        params={'name': 'foo.txt'})
 
     assert fake_fp.call_count == 0

--- a/osfclient/tests/test_utils.py
+++ b/osfclient/tests/test_utils.py
@@ -1,3 +1,4 @@
+import pytest
 from mock import call, patch, Mock
 
 from osfclient.utils import file_empty
@@ -159,6 +160,7 @@ def test_makedirs_py3(mock_makedirs):
     assert expected == mock_makedirs.mock_calls
 
 
+@pytest.mark.asyncio
 async def test_empty_file():
     fake_fp = MockStream('foobar.txt', 'rb', size=1024)
     empty = await file_empty(fake_fp)


### PR DESCRIPTION
The following error that occurred when uploading large files (>2GB) has been fixed.

```
# osf --base-url https://api.rdm.nii.ac.jp/v2/ -p ky8af upload 2GB_file osfstorage/2GB_file
Traceback (most recent call last):
  File "/usr/local/bin/osf", line 8, in <module>
    sys.exit(run_main())
             ^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/osfclient/__main__.py", line 159, in run_main
    asyncio.run(main())
  File "/usr/local/lib/python3.12/asyncio/runners.py", line 194, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/asyncio/base_events.py", line 687, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/osfclient/__main__.py", line 143, in main
    exit_code = await args.func(args)
                ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/osfclient/cli.py", line 327, in upload
    await store.create_file(remote_path, fp, force=args.force,
  File "/usr/local/lib/python3.12/site-packages/osfclient/models/storage.py", line 114, in create_file
    response = await self._put(url, params={'name': fname}, content=fp)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/osfclient/models/core.py", line 30, in _put
    return await self.session.put(url, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/osfclient/models/session.py", line 40, in put
    response = await super(OSFSession, self).put(url, *args, **kwargs_)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/httpx/_client.py", line 1942, in put
    return await self.request(
           ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/httpx/_client.py", line 1585, in request
    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/httpx/_client.py", line 1674, in send
    response = await self._send_handling_auth(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/httpx/_client.py", line 1702, in _send_handling_auth
    response = await self._send_handling_redirects(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/httpx/_client.py", line 1739, in _send_handling_redirects
    response = await self._send_single_request(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/httpx/_client.py", line 1776, in _send_single_request
    response = await transport.handle_async_request(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/httpx/_transports/default.py", line 377, in handle_async_request
    resp = await self._pool.handle_async_request(req)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 216, in handle_async_request
    raise exc from None
  File "/usr/local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 196, in handle_async_request
    response = await connection.handle_async_request(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
    return await self._connection.handle_async_request(request)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/httpcore/_async/http11.py", line 143, in handle_async_request
    raise exc
  File "/usr/local/lib/python3.12/site-packages/httpcore/_async/http11.py", line 95, in handle_async_request
    await self._send_request_body(**kwargs)
  File "/usr/local/lib/python3.12/site-packages/httpcore/_async/http11.py", line 166, in _send_request_body
    await self._send_event(event, timeout=timeout)
  File "/usr/local/lib/python3.12/site-packages/httpcore/_async/http11.py", line 175, in _send_event
    await self._network_stream.write(bytes_to_send, timeout=timeout)
  File "/usr/local/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 52, in write
    await self._stream.send(item=buffer)
  File "/usr/local/lib/python3.12/site-packages/anyio/streams/tls.py", line 211, in send
    await self._call_sslobject_method(self._ssl_object.write, item)
  File "/usr/local/lib/python3.12/site-packages/anyio/streams/tls.py", line 140, in _call_sslobject_method
    result = func(*args)
             ^^^^^^^^^^^
  File "/usr/local/lib/python3.12/ssl.py", line 867, in write
    return self._sslobj.write(data)
           ^^^^^^^^^^^^^^^^^^^^^^^^
ssl.SSLError: [BUF] malloc failure (_ssl.c:2417)
```

The following changes have been made.

- The aiofiles were behaving as if they returned all content as a single byte array, so this has been fixed.
- The OSF_CLIENT_TIMEOUT environment variable has been added to allow the upload timeout to be extended.