### PR TITLE
[GRDM-48126] Add support for httpx>=0.28.0

### DIFF
--- a/osfclient/models/file.py
+++ b/osfclient/models/file.py
@@ -7,7 +7,7 @@ from typing import AsyncGenerator, Dict, Type, TypeVar
 from .core import OSFCore
 from ..exceptions import FolderExistsException, UnauthorizedException
 from ..utils import file_empty
-from .utils import chunked_bytes_iterator
+from .utils import chunked_bytes_iterator, merge_query_params
 
 
 logger = logging.getLogger(__name__)
@@ -237,7 +237,10 @@ class ContainerMixin:
     async def create_folder(self, name, exist_ok=False):
         url = self._new_folder_url
         # Create a new sub-folder
-        response = await self._put(url, params={'name': name})
+        response = await self._put(
+            url,
+            params=merge_query_params(url, {'name': name}),
+        )
         if response.status_code == 409 and not exist_ok:
             raise FolderExistsException(name)
 

--- a/osfclient/models/storage.py
+++ b/osfclient/models/storage.py
@@ -17,7 +17,7 @@ from ..utils import is_folder
 from ..utils import checksum_fp
 from ..utils import norm_remote_path
 from ..utils import find_by_path
-from .utils import chunked_bytes_iterator
+from .utils import chunked_bytes_iterator, merge_query_params
 
 
 logger = logging.getLogger(__name__)
@@ -107,14 +107,18 @@ class Storage(OSFCore, ContainerMixin):
         # See: https://github.com/osfclient/osfclient/pull/135
         if await file_empty(fp):
             logger.info("File is empty, uploading zero-length bytes.")
-            response = await self._put(url, params={'name': fname}, content=b'')
+            response = await self._put(
+                url,
+                params=merge_query_params(url, {'name': fname}),
+                content=b''
+            )
 
         else:
             logger.info("Uploading file: %s", path)
             try:
                 response = await self._put(
                     url,
-                    params={'name': fname},
+                    params=merge_query_params(url, {'name': fname}),
                     content=chunked_bytes_iterator(fp) if hasattr(fp, 'read') else fp,
                 )
             except HTTPError:

--- a/osfclient/models/utils.py
+++ b/osfclient/models/utils.py
@@ -1,4 +1,5 @@
-from typing import Any, AsyncIterable
+from typing import Any, AsyncIterable, Dict
+from urllib.parse import urlparse, parse_qs
 
 
 DEFAULT_UPLOAD_BLOCK_SIZE = 1024 * 1024 * 128  # 128 MB
@@ -16,3 +17,11 @@ async def chunked_bytes_iterator(
         if len(chunk) == 0:
             break
         yield chunk
+
+def merge_query_params(url: str, params: Dict[str, str]) -> Dict[str, str]:
+    """Merge query parameters into a new dictionary with the existing query parameters of a URL."""
+    parsed_url = urlparse(url)
+    query = parse_qs(parsed_url.query)
+    new_query = dict([(k, v[0]) for k, v in query.items()])
+    new_query.update(params)
+    return new_query

--- a/osfclient/tests/test_file.py
+++ b/osfclient/tests/test_file.py
@@ -117,7 +117,7 @@ async def test_create_existing_folder():
         await folder.create_folder('foobar')
 
     folder._put.assert_called_once_with(new_folder_url,
-                                        params={'name': 'foobar'})
+                                        params={'kind': 'folder', 'name': 'foobar'})
 
 
 @pytest.mark.asyncio
@@ -136,7 +136,7 @@ async def test_create_existing_folder_exist_ok():
     assert existing_folder.name == 'foobar'
 
     folder._put.assert_called_once_with(new_folder_url,
-                                        params={'name': 'foobar'})
+                                        params={'kind': 'folder', 'name': 'foobar'})
 
 
 @pytest.mark.asyncio
@@ -153,7 +153,7 @@ async def test_create_new_folder():
     assert isinstance(new_folder, Folder)
 
     folder._put.assert_called_once_with(new_folder_url,
-                                        params={'name': 'foobar'})
+                                        params={'kind': 'folder', 'name': 'foobar'})
 
 
 @pytest.mark.asyncio

--- a/osfclient/tests/test_storage.py
+++ b/osfclient/tests/test_storage.py
@@ -428,7 +428,7 @@ async def test_create_new_file_subdirectory(mock_chunked_bytes_iterator):
 
     mock_chunked_bytes_iterator.assert_called_once_with(fake_fp)
 
-    expected = [call(new_folder_url, params={'name': 'bar'}),
+    expected = [call(new_folder_url, params={'kind': 'folder', 'name': 'bar'}),
                 call(new_file_url, params={'name': 'foo.txt'}, content=b'TEST')]
     assert mock_put.call_args_list == expected
     assert fake_fp.call_count == 0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-httpx
+httpx>=0.28.1
 tqdm
 six
 python-dateutil


### PR DESCRIPTION
Creating folders becomes creating empty files when used with httpx >= 0.28.0 due to the following changes to httpx.

https://github.com/encode/httpx/pull/3364

When creating a folder, rdmclient uses the new_folder URL passed from WaterButler. This contains the `kind=folder` parameter, and the folder is created by passing `name=folder` name in addition to this parameter.
This is a behavior that expects httpx to combine the query parameters given in the url argument with the query parameters given in params, but the above pull request has changed it to use only params.

This pull request will add support for the new behavior of httpx.

Note that this problem can be temporarily avoided by downgrading httpx.

```
pip install httpx==0.27.0
```
