### PR TITLE
[MRG] Fix S3 file download failing with 403 SignatureDoesNotMatch

### DIFF
--- a/osfclient/tests/test_session.py
+++ b/osfclient/tests/test_session.py
@@ -1,6 +1,5 @@
 import asyncio
-from mock import patch
-from mock import MagicMock
+from mock import patch, MagicMock, AsyncMock
 
 import pytest
 
@@ -91,3 +90,112 @@ async def test_get(mock_get):
 
     assert response == mock_response
     mock_get.assert_called_once_with(url, follow_redirects=True)
+
+
+# Tests for stream method with redirect handling
+
+@pytest.mark.asyncio
+@patch('osfclient.models.session.httpx.AsyncClient.stream')
+async def test_stream_no_redirect(mock_stream):
+    """When response is 200 OK, yield response directly without redirect handling."""
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.headers = {}
+
+    mock_stream.return_value.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_stream.return_value.__aexit__ = AsyncMock(return_value=None)
+
+    session = OSFSession()
+    async with session.stream('GET', 'http://localhost:7777/download') as response:
+        assert response.status_code == 200
+        assert response is mock_response
+
+
+@pytest.mark.asyncio
+@patch('osfclient.models.session.httpx.AsyncClient')
+@patch('osfclient.models.session.httpx.AsyncClient.stream')
+async def test_stream_redirect(mock_parent_stream, mock_client_class):
+    """When response is a redirect, follow with clean headers."""
+    # Mock the initial response (302 redirect)
+    mock_initial_response = MagicMock()
+    mock_initial_response.status_code = 302
+    mock_initial_response.headers = {'location': 'https://s3.amazonaws.com/bucket/file?Signature=xxx'}
+
+    mock_parent_stream.return_value.__aenter__ = AsyncMock(return_value=mock_initial_response)
+    mock_parent_stream.return_value.__aexit__ = AsyncMock(return_value=None)
+
+    # Mock the redirect response (200 OK with content)
+    mock_redirect_response = MagicMock()
+    mock_redirect_response.status_code = 200
+
+    mock_redirect_stream = MagicMock()
+    mock_redirect_stream.return_value.__aenter__ = AsyncMock(return_value=mock_redirect_response)
+    mock_redirect_stream.return_value.__aexit__ = AsyncMock(return_value=None)
+
+    mock_client_instance = MagicMock()
+    mock_client_instance.stream = mock_redirect_stream
+    mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
+    mock_client_instance.__aexit__ = AsyncMock(return_value=None)
+    mock_client_class.return_value = mock_client_instance
+
+    session = OSFSession()
+    async with session.stream('GET', 'http://localhost:7777/download') as response:
+        assert response.status_code == 200
+        assert response is mock_redirect_response
+
+    # Verify clean headers are used (no Content-Type, no Accept)
+    call_args = mock_redirect_stream.call_args
+    headers = call_args.kwargs.get('headers', {})
+    assert 'User-Agent' in headers
+    assert 'Accept-Charset' in headers
+    assert 'Content-Type' not in headers
+    assert 'Accept' not in headers
+
+
+@pytest.mark.asyncio
+@patch('osfclient.models.session.httpx.AsyncClient')
+@patch('osfclient.models.session.httpx.AsyncClient.stream')
+async def test_stream_redirect_headers_not_forwarded(mock_parent_stream, mock_client_class):
+    """Verify that API-specific headers (Content-Type, Accept, Authorization) are NOT forwarded on redirect."""
+    # Mock the initial response (302 redirect)
+    mock_initial_response = MagicMock()
+    mock_initial_response.status_code = 302
+    mock_initial_response.headers = {'location': 'https://s3.amazonaws.com/bucket/file'}
+
+    mock_parent_stream.return_value.__aenter__ = AsyncMock(return_value=mock_initial_response)
+    mock_parent_stream.return_value.__aexit__ = AsyncMock(return_value=None)
+
+    # Mock the redirect response (200 OK)
+    mock_redirect_response = MagicMock()
+    mock_redirect_response.status_code = 200
+
+    mock_redirect_stream = MagicMock()
+    mock_redirect_stream.return_value.__aenter__ = AsyncMock(return_value=mock_redirect_response)
+    mock_redirect_stream.return_value.__aexit__ = AsyncMock(return_value=None)
+
+    mock_client_instance = MagicMock()
+    mock_client_instance.stream = mock_redirect_stream
+    mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
+    mock_client_instance.__aexit__ = AsyncMock(return_value=None)
+    mock_client_class.return_value = mock_client_instance
+
+    session = OSFSession()
+    # Add Authorization header
+    session.token_auth('test-token')
+
+    async with session.stream('GET', 'http://localhost:7777/download') as response:
+        pass
+
+    # Verify headers passed to redirect request
+    call_args = mock_redirect_stream.call_args
+    headers = call_args.kwargs.get('headers', {})
+
+    # Verify headers that SHOULD be present
+    assert 'User-Agent' in headers
+    assert headers['User-Agent'] == 'osfclient v0.0.1'
+    assert 'Accept-Charset' in headers
+
+    # Verify headers that MUST NOT be present (API-specific headers)
+    assert 'Content-Type' not in headers
+    assert 'Accept' not in headers
+    assert 'Authorization' not in headers


### PR DESCRIPTION
### Summary

Added safe redirect handling for S3 in streaming methods to avoid forwarding specific headers that break presigned URL signatures.

### Background

`OSFSession` attaches default headers including `Content-Type` and `Accept` to every request. However, the WaterButler S3 provider does not include these headers when generating presigned URLs. When the rdmclient follows a redirect to a presigned URL **while forwarding those extra headers**, the signature no longer matches and S3 returns `403 SignatureDoesNotMatch`.

### Changed

When a streaming request is redirected to a presigned URL, this change forwards only the headers that are expected/covered by the presigning process, and avoids forwarding specific headers that invalidates the signature.

### Scope

This affects only **`GET`** requests that follow redirects to presigned URLs returned by the corresponding WaterButler providers. Currently relevant providers include:
- S3
- Azure Blob Storage
- Figshare